### PR TITLE
Fixes #1 - Allow specifying protocol via setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,22 @@ Then add it to your ``INSTALLED_APPS``::
     )
 
 
+Settings
+--------
+
+The protocol of the uris returned by this library defaults to ``http``.  You
+can specify the protocol with the ``ABSOLUTEURI_PROTOCOL`` setting.
+
+.. code:: python
+
+    # settings.py
+    ABSOLUTEURI_PROTOCOL = 'https'
+
+    # Elsewhere
+    >>> absoluteuri.build_absolute_uri('/some/path/')
+    'https://example.com/some/path/'
+
+
 Template Tags
 -------------
 

--- a/absoluteuri/__init__.py
+++ b/absoluteuri/__init__.py
@@ -1,6 +1,7 @@
 import pkg_resources
 
 from django.core import urlresolvers
+from django.conf import settings
 
 __version__ = pkg_resources.get_distribution('django-absoluteuri').version
 
@@ -10,7 +11,7 @@ def build_absolute_uri(path):
     from django.contrib.sites.models import Site
     site = Site.objects.get_current()
     return '{protocol}://{domain}{path}'.format(
-        protocol='http',
+        protocol=getattr(settings, 'ABSOLUTEURI_PROTOCOL', 'http'),
         domain=site.domain,
         path=path
     )

--- a/absoluteuri/tests.py
+++ b/absoluteuri/tests.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 from django.template import Template, Context
 from django.conf.urls import url
 
+import absoluteuri
+
 
 def view(request, *args, **kwargs):
     pass
@@ -36,3 +38,17 @@ class AbsoluteURITestCase(TestCase):
         template = "{% load absoluteuri %}{% absolutize path %}"
         rendered = self.render_template(template, path='/url/path/')
         self.assertEqual(rendered, 'http://example.com/url/path/')
+
+    def test_protocol_with_setting_not_set(self):
+        uri = absoluteuri.build_absolute_uri('/url/path/')
+        self.assertEqual(uri, 'http://example.com/url/path/')
+
+    def test_protocol_with_setting_not_set_as_http(self):
+        with self.settings(ABSOLUTEURI_PROTOCOL='http'):
+            uri = absoluteuri.build_absolute_uri('/url/path/')
+            self.assertEqual(uri, 'http://example.com/url/path/')
+
+    def test_protocol_with_setting_not_set_as_https(self):
+        with self.settings(ABSOLUTEURI_PROTOCOL='https'):
+            uri = absoluteuri.build_absolute_uri('/url/path/')
+            self.assertEqual(uri, 'https://example.com/url/path/')


### PR DESCRIPTION
### What is the problem / feature ?

It'd be nice to be able to get `https` urls back from this library.
### How did it get fixed / implemented ?

Added a new setting `ABSOLUTEURI_PROTOCOL` that allows you to specify the protocol.  If unset, it defaults to `http`
### How can someone test / see it ?

Set the `ABSOLUTEURI_PROTOCOL` setting to `https` and see that you get `https` urls.  Also tests.

_Here is a cute animal picture for your troubles..._

![image-4-for-unlikely-animal-friends-gallery-359755382](https://cloud.githubusercontent.com/assets/824194/6785350/ad4dfc4c-d14a-11e4-9819-d8587b3e008d.jpg)
