### PR TITLE
Support reverse from Django 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pep8.txt
 dist/
 build/
 .tox
+venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TOX_ENV=py26-dj14
   - TOX_ENV=py27-dj17
   - TOX_ENV=py33-dj17
+  - TOX_ENV=py36-dj20
 install:
   - pip install --upgrade pip
   - pip install tox==1.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,16 @@ python:
 cache:
   directories:
     - $HOME/.pip-cache/
-env:
-  - TOX_ENV=py26-dj14
-  - TOX_ENV=py27-dj17
-  - TOX_ENV=py33-dj17
-  - TOX_ENV=py36-dj20
+matrix:
+  include:
+  - python: "2.6"
+    env: TOX_ENV=py26-dj14
+  - python: "2.7"
+    env: TOX_ENV=py27-dj17
+  - python: "3.3"
+    env: TOX_ENV=py33-dj17
+  - python: "3.6"
+    env: TOX_ENV=py36-dj20
 install:
   - pip install --upgrade pip
   - pip install tox==1.8.0

--- a/absoluteuri/__init__.py
+++ b/absoluteuri/__init__.py
@@ -1,7 +1,13 @@
 import pkg_resources
 
-from django.core import urlresolvers
 from django.conf import settings
+
+try:
+    # Will be removed in Django 2.0
+    from django.core import urlresolvers
+except ImportError:
+    import django.urls as urlresolvers
+
 
 __version__ = pkg_resources.get_distribution('django-absoluteuri').version
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -15,3 +15,7 @@ DATABASES = {
 SITE_ID = 1
 
 ROOT_URLCONF = 'absoluteuri.tests'
+
+TEMPLATES = [
+    {'BACKEND': 'django.template.backends.django.DjangoTemplates'}
+]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
 envlist=
     py26-dj14,
-    py{27,33}-dj{17}
+    py{27,33}-dj{17},
+    py36-dj20
 
 [testenv]
 basepython=
   py26: python2.6
   py27: python2.7
   py33: python3.3
+  py36: python3.6
 commands=
   /usr/bin/env
   python setup.py test
@@ -15,5 +17,6 @@ deps=
   dj14: Django>=1.4,<1.5
   py26: argparse
   dj17: Django>=1.7,<1.8
+  dj20: Django>=2.0
 whitelist_externals=
   env


### PR DESCRIPTION
The **django.core.urlresolvers** module is removed in favor of its new location, **django.urls**.

Closes #8 